### PR TITLE
Normalize shots collisions detections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+PROCESSING_IDE:=/usr/share/processing/processing-3.5.4/processing
 PROCESSING_JAVA:=/usr/share/processing/processing-3.5.4/processing-java
 SKETCH_NAME:=space_invaders
 
@@ -9,3 +10,6 @@ start:
 
 build:
 	$(PROCESSING_JAVA) --sketch=$(SKETCH_NAME)/ --output=build --build
+
+ide:
+	$(PROCESSING_IDE) $(SKETCH_NAME)/$(SKETCH_NAME).pde

--- a/space_invaders/space_invaders.pde
+++ b/space_invaders/space_invaders.pde
@@ -125,10 +125,15 @@ void draw() {
 		}
 	}
 	
-	//
+	// move invaders down when they reached sides of the scene
 	for (int k = 0; k < scene.invaders.size(); k++) {
 		invader = scene.invaders.get(k);
 		invader.move(invadersDx, borderReached ? invadersDy : 0);
+	}
+
+	// if no invaders remains, game is finished
+	if(scene.invaders.size() == 0){
+		scene.gameOver("You win!");
 	}
 }
 

--- a/space_invaders/space_invaders.pde
+++ b/space_invaders/space_invaders.pde
@@ -1,7 +1,6 @@
 //
 Scene scene;
 Player player;
-Shot playerShot;
 
 HashMap<Integer, PImage> loadInvadersSprites(Integer size) {
 	HashMap<Integer, PImage> sprites = new HashMap();
@@ -32,9 +31,6 @@ void newGame(Scene scene, int invadersRows, int invadersCols) {
 			new Invader(scene, j, i, invadersSize, invadersSprites.get(i));
 		}
 	}
-	
-	// initialize shots
-	playerShot = null;
 	
 	// TODO: remove this test
 	new Shot(scene, GROUP_INVADERS, 500, 50, 2);
@@ -100,26 +96,6 @@ void draw() {
 		invader.move(invadersDx, borderReached ? invadersDy : 0);
 	}
 	
-	if (playerShot != null) {		
-		// move player shot
-		if (!playerShot.move()) {
-			// if no move, border was reached, delete shot entity and reset lock.
-			playerShot.destroy();
-			playerShot = null;
-		} else{
-			// foreach invader, check if it is hit!
-			for (int k = scene.invaders.size() - 1; k>- 1; k--) {
-				// if so, remove invader and shot entities
-				if (playerShot.hurt(scene.invaders.get(k))) {
-					scene.removeInvader(scene.invaders.get(k));
-					playerShot.destroy();
-					
-					playerShot = null;
-					break;
-				}
-			}
-		}
-	}
 	
 	// move each shot to the next step
 	for (int k = 0; k < scene.shots.size(); k++) {
@@ -155,9 +131,10 @@ void keyPressed() {
 			int invadersRow = 3;
 			int invadersCols = 4;
 			newGame(scene, invadersRow, invadersCols);
-		} if (playerShot == null) {
-			// instanciate a shot
-			playerShot = new Laser(scene, GROUP_PLAYER, this.player.x, this.scene.earth.earthOffset + int(0.2 * this.player.size), - 8);
+		} if (player.canShot()) {
+			// make player shot
+			player.shot();
+			//new Laser(scene, GROUP_PLAYER, this.player.x, this.scene.earth.earthOffset + int(0.2 * this.player.size), - 8);
 		}
 		break;
 	}


### PR DESCRIPTION
# Normalize shots collisions detections #1 

- add a property `Shot Player.shotInstance`
- add a method `void Player.shot()`
- pass spawner entity to Shot
- when a shot is destroyed, call `entity.onShotDestroy()`
